### PR TITLE
Refactor to add some useful CLI options

### DIFF
--- a/src/unicodeitplus/__init__.py
+++ b/src/unicodeitplus/__init__.py
@@ -6,9 +6,10 @@ try:
 except Exception:
     pass
 
-from .parser import parser
+from .parser import make_parser
+from .transform import ToUnicode
 
-__all__ = ["replace", "parse"]
+__all__ = ["UnicodeItPlus"]
 
 
 def parse(s: str) -> str:
@@ -19,3 +20,16 @@ def parse(s: str) -> str:
 def replace(s: str) -> str:
     """Replace simple LaTeX code by unicode approximation."""
     return parse(f"${s}$")
+
+class UnicodeItPlus():
+    def __init__(self, options = None):
+        transformer = ToUnicode(options)
+        self.parser = make_parser(transformer)
+    
+    def parse(self, s: str) -> str:
+        """Parse simple LaTeX code and replace it by an unicode approximation."""
+        return self.parser.parse(s)
+
+    def replace(self, s: str) -> str:
+        """Replace simple LaTeX code by unicode approximation."""
+        return self.parser.parse(f"${s}$")

--- a/src/unicodeitplus/cli.py
+++ b/src/unicodeitplus/cli.py
@@ -9,6 +9,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument("-r", "--preserve-roman", action="store_true", help="Do not italicize roman letters (A-Z a-z) in math")
     parser.add_argument("-w", "--preserve-math-whitespace", action="store_true", help="Preserve whitespace between math characters")
+    parser.add_argument("-p", "--preamble", action="store", help="Override data file from a JSON file with custom commands")
     parser.add_argument("ARG", nargs="+", help="some LaTeX code")
     args = parser.parse_args()
     options_dict = vars(args)

--- a/src/unicodeitplus/cli.py
+++ b/src/unicodeitplus/cli.py
@@ -7,6 +7,8 @@ from unicodeitplus import UnicodeItPlus
 def main() -> int:
     """Convert simple LaTeX into an unicode approximation to paste anywhere."""
     parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument("-r", "--preserve-roman", action="store_true")
+    parser.add_argument("-w", "--preserve-math-whitespace", action="store_true")
     parser.add_argument("ARG", nargs="+", help="some LaTeX code")
     args = parser.parse_args()
     options_dict = vars(args)

--- a/src/unicodeitplus/cli.py
+++ b/src/unicodeitplus/cli.py
@@ -7,8 +7,8 @@ from unicodeitplus import UnicodeItPlus
 def main() -> int:
     """Convert simple LaTeX into an unicode approximation to paste anywhere."""
     parser = argparse.ArgumentParser(description=main.__doc__)
-    parser.add_argument("-r", "--preserve-roman", action="store_true")
-    parser.add_argument("-w", "--preserve-math-whitespace", action="store_true")
+    parser.add_argument("-r", "--preserve-roman", action="store_true", help="Do not italicize roman letters (A-Z a-z) in math")
+    parser.add_argument("-w", "--preserve-math-whitespace", action="store_true", help="Preserve whitespace between math characters")
     parser.add_argument("ARG", nargs="+", help="some LaTeX code")
     args = parser.parse_args()
     options_dict = vars(args)

--- a/src/unicodeitplus/cli.py
+++ b/src/unicodeitplus/cli.py
@@ -1,7 +1,7 @@
 """Console script for unicodeitplus."""
 import argparse
 import sys
-from unicodeitplus import replace, parse
+from unicodeitplus import UnicodeItPlus
 
 
 def main() -> int:
@@ -9,11 +9,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument("ARG", nargs="+", help="some LaTeX code")
     args = parser.parse_args()
+    options_dict = vars(args)
     sargs = " ".join(args.ARG)
+    parser = UnicodeItPlus(options_dict)
     if "$" not in sargs:
-        s = replace(sargs)
+        s = parser.replace(sargs)
     else:
-        s = parse(sargs)
+        s = parser.parse(sargs)
     sys.stdout.write(s + "\n")
     return 0
 

--- a/src/unicodeitplus/parser.py
+++ b/src/unicodeitplus/parser.py
@@ -4,7 +4,6 @@ Parser for simple LaTeX.
 This parser supports only the simple subject of LaTeX that we typically use.
 """
 from lark import Lark
-from .transform import ToUnicode
 
 grammar = r"""
 start: (item | math)*

--- a/src/unicodeitplus/parser.py
+++ b/src/unicodeitplus/parser.py
@@ -29,4 +29,5 @@ WS_EXT: WS | "~" | "\," | "\;" | "\:" | "\>"
 %import common.WORD
 """
 
-parser = Lark(grammar, parser="lalr", transformer=ToUnicode())
+def make_parser(transformer):
+    return Lark(grammar, parser="lalr", transformer=transformer)

--- a/src/unicodeitplus/parser.py
+++ b/src/unicodeitplus/parser.py
@@ -22,7 +22,7 @@ group: "{" item* "}"
 math: "$" item* "$"
 SUBSCRIPT: "_"
 SUPERSCRIPT: "^"
-COMMAND: (("\\" WORD WS*) | SUBSCRIPT | SUPERSCRIPT)
+COMMAND: (("\\" WORD) | SUBSCRIPT | SUPERSCRIPT)
 WS_EXT: WS | "~" | "\," | "\;" | "\:" | "\>"
 
 %import common.WS

--- a/src/unicodeitplus/transform.py
+++ b/src/unicodeitplus/transform.py
@@ -4,6 +4,8 @@ from .data import COMMANDS, HAS_ARG
 from lark import Transformer, Token
 from typing import List, Any
 from string import ascii_letters
+import json
+import sys
 
 
 IGNORE_AS_FALLBACK = {
@@ -52,11 +54,21 @@ class ToUnicode(Transformer):  # type:ignore
         options = options if options else dict()
         self.preserve_roman = options.get("preserve_roman", False)
         self.preserve_math_whitespace = options.get("preserve_math_whitespace", False)
+        self.preamble = options.get("preamble", None)
         
         self.commands = COMMANDS
 
         if self.preserve_roman:
             self.commands.update({ x: x for x in ascii_letters })
+
+        if self.preamble:
+            try:
+                with open(self.preamble, 'r') as f:
+                    p = json.load(f)
+                    self.commands.update(p)
+            except:
+                print('Invalid preamble file', file=sys.stderr)
+
 
     def start(self, ch: List[Any]) -> str:
         """

--- a/src/unicodeitplus/transform.py
+++ b/src/unicodeitplus/transform.py
@@ -47,6 +47,9 @@ WHITESPACE = {
 class ToUnicode(Transformer):  # type:ignore
     """Convert Tree to Unicode."""
 
+    def __init__(self, options = None):
+        options = options if options else dict()
+
     def start(self, ch: List[Any]) -> str:
         """
         Return final unicode.

--- a/src/unicodeitplus/transform.py
+++ b/src/unicodeitplus/transform.py
@@ -147,8 +147,6 @@ class ToUnicode(Transformer):  # type:ignore
 
         is_space = lambda x: isinstance(x, str) and x.isspace()
 
-        if not self.preserve_math_whitespace:
-            items = [x for x in items if not is_space(x)]
         def visitor(
             r: List[List[str]],
             stack: List[str],
@@ -165,10 +163,9 @@ class ToUnicode(Transformer):  # type:ignore
                 else:
                     if isinstance(x, list):
                         visitor(r, stack, x)
-                    elif isinstance(x, str):
+                    elif not is_space(x) or self.preserve_math_whitespace:
                         r.append(stack.copy() + [x])
-                    else:
-                        assert False  # should never happen
+                    
                     if not is_space(x):
                         stack[:] = initial_stack
 

--- a/src/unicodeitplus/transform.py
+++ b/src/unicodeitplus/transform.py
@@ -122,6 +122,7 @@ class ToUnicode(Transformer):  # type:ignore
         unicode. See comments in that function for details.
         """
 
+        items = [x for x in items if isinstance(x, list) or (isinstance(x, str) and not x.isspace())]
         def visitor(
             r: List[List[str]],
             stack: List[str],

--- a/src/unicodeitplus/transform.py
+++ b/src/unicodeitplus/transform.py
@@ -151,36 +151,36 @@ class ToUnicode(Transformer):  # type:ignore
 
         r: List[List[str]] = []
         visitor(r, [], items)
-        return "".join(_handle_cmds(x[:-1], x[-1]) for x in r)
+        return "".join(self._handle_cmds(x[:-1], x[-1]) for x in r)
 
 
-def _handle_cmds(cmds: List[str], x: str) -> str:
-    # - x can be character or command, like \alpha
-    # - cmds contains commands to apply, may be empty
-    # - to transform ^{\alpha} or \text{x} correctly,
-    #   we first try to convert innermost command and x
-    #   as unit; if this fails we treat commands sequentially
-    # - other commands in cmds must be modifiers like \dot or
-    #   \vec that are converted into diacritical characters
-    # - if we cannot convert, we return unconverted LaTeX
-    if cmds:
-        innermost = True
-        for cmd in reversed(cmds):
-            latex = f"{cmd}{{{x}}}"
-            if latex in COMMANDS:
-                x = COMMANDS[latex]
-            elif cmd in (r"\text", r"\mathrm"):
-                pass
-            else:
-                if innermost:
-                    x = COMMANDS.get(x, x)
-                if cmd in COMMANDS:
-                    # must be some unicode modifier, e.g. \dot, \vec
-                    assert cmd in HAS_ARG  # nosec
-                    x += COMMANDS[cmd]
-                elif cmd not in IGNORE_AS_FALLBACK:
-                    x = latex
-            innermost = False
-    else:
-        x = COMMANDS.get(x, x)
-    return x
+    def _handle_cmds(self, cmds: List[str], x: str) -> str:
+        # - x can be character or command, like \alpha
+        # - cmds contains commands to apply, may be empty
+        # - to transform ^{\alpha} or \text{x} correctly,
+        #   we first try to convert innermost command and x
+        #   as unit; if this fails we treat commands sequentially
+        # - other commands in cmds must be modifiers like \dot or
+        #   \vec that are converted into diacritical characters
+        # - if we cannot convert, we return unconverted LaTeX
+        if cmds:
+            innermost = True
+            for cmd in reversed(cmds):
+                latex = f"{cmd}{{{x}}}"
+                if latex in COMMANDS:
+                    x = COMMANDS[latex]
+                elif cmd in (r"\text", r"\mathrm"):
+                    pass
+                else:
+                    if innermost:
+                        x = COMMANDS.get(x, x)
+                    if cmd in COMMANDS:
+                        # must be some unicode modifier, e.g. \dot, \vec
+                        assert cmd in HAS_ARG  # nosec
+                        x += COMMANDS[cmd]
+                    elif cmd not in IGNORE_AS_FALLBACK:
+                        x = latex
+                innermost = False
+        else:
+            x = COMMANDS.get(x, x)
+        return x

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,5 +1,7 @@
 import pytest
-from unicodeitplus import parse, replace
+from unicodeitplus import UnicodeItPlus
+
+parser = UnicodeItPlus()
 
 REPLACE_TEST_CASES = {
     r"\infty": "∞",
@@ -37,7 +39,7 @@ REPLACE_TEST_CASES = {
 @pytest.mark.parametrize("latex", REPLACE_TEST_CASES)
 def test_replace(latex):
     expected = REPLACE_TEST_CASES[latex]
-    got = replace(latex)
+    got = parser.replace(latex)
     assert expected == got
 
 
@@ -64,5 +66,5 @@ PARSE_TEST_CASES = {
 @pytest.mark.parametrize("latex", PARSE_TEST_CASES)
 def test_parse(latex):
     expected = PARSE_TEST_CASES[latex]
-    got = parse(latex)
+    got = parser.parse(latex)
     assert expected == got

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -2,6 +2,8 @@ import pytest
 from unicodeitplus import UnicodeItPlus
 
 parser = UnicodeItPlus()
+parser_w = UnicodeItPlus({ 'preserve_math_whitespace': True })
+parser_r = UnicodeItPlus({ 'preserve_roman': True })
 
 REPLACE_TEST_CASES = {
     r"\infty": "∞",
@@ -68,3 +70,24 @@ def test_parse(latex):
     expected = PARSE_TEST_CASES[latex]
     got = parser.parse(latex)
     assert expected == got
+
+OPTION_TEST_CASES = {
+    "preserve_whitespace": {
+        r"$\sqrt{a} + b^2 \in \mathcal{S} \cdot \mathbb{R}$": "√𝑎̅ + 𝑏² ∈ 𝒮 ⋅ ℝ",
+        r"$x^1_1 \cdot   y = \int_a^b   f(x) dx$ foo bar": "𝑥¹₁ ⋅ 𝑦 = ∫ₐᵇ 𝑓(𝑥) 𝑑𝑥 foo bar",
+    },
+    "preserve_roman": {
+        r"$a \cdot \mathbb{R}$": "a⋅ℝ",
+        r"foo $a \mathbf{a} b \mathbf{b} A Z$ bar": "foo a𝐚b𝐛AZ bar",
+    },
+}
+
+def test_options():
+    for latex in OPTION_TEST_CASES["preserve_whitespace"]:
+        expected = OPTION_TEST_CASES["preserve_whitespace"][latex]
+        got = parser_w.parse(latex)
+        assert expected == got
+    for latex in OPTION_TEST_CASES["preserve_roman"]:
+        expected = OPTION_TEST_CASES["preserve_roman"][latex]
+        got = parser_r.parse(latex)
+        assert expected == got


### PR DESCRIPTION
Hello! I wanted to modify this program for some of my use cases, and decided it would be easy enough to implement these cases as CLI options. As such, this is a sizeable PR with quite a bit of refactoring; I'm completely open to different naming, etc., if you have opinions.

I've added CLI options:

```
options:
  -h, --help            show this help message and exit
  -r, --preserve-roman  Do not italicize roman letters (A-Z a-z) in math
  -w, --preserve-math-whitespace
                        Preserve whitespace between math characters
  -p PREAMBLE, --preamble PREAMBLE
                        Override data file from a JSON file with custom commands
```

The first two are self-explanatory, and the preamble option is an extensible solution for users that wish to change or alter symbols from `unicodemathsymbols.txt` (or use their own "macros") without relying on the program author to make such a change.

All the existing tests pass, and I've added a few tests for the CLI options as well.